### PR TITLE
Update api.py

### DIFF
--- a/api/app/api.py
+++ b/api/app/api.py
@@ -2,7 +2,7 @@ from __version__ import api_version
 from flask import Blueprint
 from flask_restplus import Api
 
-#Testing if it works
+#Change naming of api title
 
 class API:
     def __init__(self, namespace_list):


### PR DESCRIPTION
The api naming convention does not reflect the standard naming convention. Please change to remove confusion